### PR TITLE
fix(grain): Correct list lifting

### DIFF
--- a/crates/grain/src/lib.rs
+++ b/crates/grain/src/lib.rs
@@ -2492,6 +2492,9 @@ impl Bindgen for FunctionBindgen<'_, '_> {
 
                 self.push_str("for (let mut i = WasmI32.(-)(");
                 self.push_str(&len);
+                // We loop from the end of the list to the start,
+                // because wasm is unsigned when we hit `0` we'll loop back around to `-1`
+                // and exit the loop.
                 self.push_str(", 1n); WasmI32.(!=)(i, -1n); i = WasmI32.(-)(i, 1n)) {\n");
                 self.push_str("let base = WasmI32.(+)(");
                 self.push_str(&base);

--- a/crates/grain/src/lib.rs
+++ b/crates/grain/src/lib.rs
@@ -2495,7 +2495,7 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 self.push_str("; WasmI32.gtU(i, 0n); i = WasmI32.(-)(i, 1n)) {\n");
                 self.push_str("let base = WasmI32.(+)(");
                 self.push_str(&base);
-                self.push_str(", WasmI32.(*)(i, ");
+                self.push_str(", WasmI32.(*)(WasmI32.(-)(i, 1n), ");
                 self.push_str(&size.to_string());
                 self.push_str("n))\n");
                 self.push_str(&body);

--- a/crates/grain/src/lib.rs
+++ b/crates/grain/src/lib.rs
@@ -2490,12 +2490,12 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 self.push_str(&format!("let mut {} = []\n", result));
                 self.push_str(&format!("Memory.incRef(WasmI32.fromGrain({}))\n", result));
 
-                self.push_str("for (let mut i = ");
+                self.push_str("for (let mut i = WasmI32.(-)(");
                 self.push_str(&len);
-                self.push_str("; WasmI32.gtU(i, 0n); i = WasmI32.(-)(i, 1n)) {\n");
+                self.push_str(", 1n); WasmI32.(!=)(i, -1n); i = WasmI32.(-)(i, 1n)) {\n");
                 self.push_str("let base = WasmI32.(+)(");
                 self.push_str(&base);
-                self.push_str(", WasmI32.(*)(WasmI32.(-)(i, 1n), ");
+                self.push_str(", WasmI32.(*)(i, ");
                 self.push_str(&size.to_string());
                 self.push_str("n))\n");
                 self.push_str(&body);

--- a/crates/grain/src/lib.rs
+++ b/crates/grain/src/lib.rs
@@ -2490,9 +2490,9 @@ impl Bindgen for FunctionBindgen<'_, '_> {
                 self.push_str(&format!("let mut {} = []\n", result));
                 self.push_str(&format!("Memory.incRef(WasmI32.fromGrain({}))\n", result));
 
-                self.push_str("for (let mut i = WasmI32.(-)(");
+                self.push_str("for (let mut i = ");
                 self.push_str(&len);
-                self.push_str(", 1n); WasmI32.gtU(i, 0n); i = WasmI32.(-)(i, 1n)) {\n");
+                self.push_str("; WasmI32.gtU(i, 0n); i = WasmI32.(-)(i, 1n)) {\n");
                 self.push_str("let base = WasmI32.(+)(");
                 self.push_str(&base);
                 self.push_str(", WasmI32.(*)(i, ");


### PR DESCRIPTION
I noticed that when you pass a list into grain it was missing one element below is the previous code for handling the lifting:
```rs
Memory.incRef(WasmI32.fromGrain(result_list_lift))
for (let mut i = WasmI32.(-)(len_list_lift, 1n); WasmI32.gtU(i, 0n); i = WasmI32.(-)(i, 1n)) {
  let base = WasmI32.(+)(base_list_lift, WasmI32.(*)(i, 4n))
  let handle_lift = {handle: WasmI32.toGrain(DataStructures.newInt32(WasmI32.load(base, 0n))),}: WebElement
  result_list_lift = [handle_lift, ...result_list_lift]
}
```
as you can see we initialize `i` from the top of the list `WasmI32.(-)(len_list_lift, 1n)` and iterate to the bottom of the list `WasmI32.gtU(i, 0n)` you may notice that we were taking two of the length because of the `gt` and `- 1n`,The bug came from the `WasmI32.(-)(len_list_lift, 1n)` and the solution is just to use `len_list_lift`. We also now need to subtract one when we are calculating `base`. 

It may be noticed that if we switched `gtU` to `geU` we could solve this with less instructions the problem here is that when we wrap to `-1` because we are working in `unsigned` territory `-1` is greater than `0`, we could switch to `>=` but then we would not be able to map anything outside of the range of `(2^32)/2-1`