### PR TITLE
fix(grain): Correct empty resource generation

### DIFF
--- a/crates/grain/src/lib.rs
+++ b/crates/grain/src/lib.rs
@@ -165,21 +165,22 @@ impl WorldGenerator for Grain {
                     _ => false,
                 })
                 .collect();
-
-            gen.src.push_str("\nprovide module ");
-            gen.src.push_str(
-                &resolve.types[**resource]
-                    .name
-                    .as_ref()
-                    .unwrap()
-                    .to_upper_camel_case(),
-            );
-            gen.src.push_str(" {");
-            for (_name, func) in resource_funcs.iter() {
-                gen.src.push_str("\n");
-                gen.import(resolve, func);
+            if resource_funcs.len() > 0 {
+                gen.src.push_str("\nprovide module ");
+                gen.src.push_str(
+                    &resolve.types[**resource]
+                        .name
+                        .as_ref()
+                        .unwrap()
+                        .to_upper_camel_case(),
+                );
+                gen.src.push_str(" {");
+                for (_name, func) in resource_funcs.iter() {
+                    gen.src.push_str("\n");
+                    gen.import(resolve, func);
+                }
+                gen.src.push_str("}\n");
             }
-            gen.src.push_str("}\n");
         }
         gen.src.push_str("}\n\n");
         gen.finish();


### PR DESCRIPTION
This pr corrects the way we generate bindings for:
```
resource file {}
```
before we would generate an empty module which didn't really make sense so now this just generates the type defintion for the resource handle if there is no functions.


This pr currently is built ontop of  the changes in #2 so it needs to be merged first, I can seperate these if needed but it was easier for me to just combine them so I had a working branch.